### PR TITLE
New persist_failure end event introduced in Contract::Persist

### DIFF
--- a/test/operation/contract_test.rb
+++ b/test/operation/contract_test.rb
@@ -70,14 +70,14 @@ class ContractTest < Minitest::Spec
     class New < Upsert
     end
 
-    it { Trailblazer::Operation::Inspect.(New).must_equal %{[>model.build,>contract.build,>contract.default.validate,>persist.save]} }
+    it { Trailblazer::Operation::Inspect.(New).must_equal %{[>model.build,>contract.build,>contract.default.validate,>contract.default.persist]} }
 
     #- overwriting Validate
     class NewHit < Upsert
       step Contract::Validate( key: :hit ), override: true
     end
 
-    it { Trailblazer::Operation::Inspect.(NewHit).must_equal %{[>model.build,>contract.build,>contract.default.validate,>persist.save]} }
+    it { Trailblazer::Operation::Inspect.(NewHit).must_equal %{[>model.build,>contract.build,>contract.default.validate,>contract.default.persist]} }
     it { NewHit.(params: {:hit => { title: "Hooray For Me" }}).inspect(:model).must_equal %{<Result:true [#<struct ContractTest::Song title=\"Hooray For Me\">] >} }
   end
 end

--- a/test/operation/persist_test.rb
+++ b/test/operation/persist_test.rb
@@ -2,7 +2,9 @@ require "test_helper"
 
 class PersistTest < Minitest::Spec
   Song = Struct.new(:title, :saved) do
-    def save; title=="Fail!" ? false : self.saved = true; end
+    def save
+      title == "Fail!" ? false : self.saved = true
+    end
   end
 
   class Create < Trailblazer::Operation
@@ -42,7 +44,10 @@ class PersistTest < Minitest::Spec
   class Update < Create
   end
 
-  it { Trailblazer::Operation::Inspect.( Update ).must_equal %{[>model.build,>contract.build,>contract.default.validate,<<PersistTest::Create::Fail1,>persist.save,<<PersistTest::Create::Fail2]} }
+  it do
+    Trailblazer::Operation::Inspect.( Update )
+      .must_equal %{[>model.build,>contract.build,>contract.default.validate,<<PersistTest::Create::Fail1,>contract.default.persist,<<PersistTest::Create::Fail2]}
+  end
 
   #---
   it do


### PR DESCRIPTION
This could be used to add error handler after Contract::Persist to recover/show error in case model.send(method) fails