### PR TITLE
Fix issue #9. Skip extract when a representer is passed as argument.

### DIFF
--- a/lib/trailblazer/operation/validate.rb
+++ b/lib/trailblazer/operation/validate.rb
@@ -22,7 +22,7 @@ module Trailblazer
         options = {task: activity, id: "contract.#{name}.validate", outputs: activity.outputs}
 
         # Deviate End.extract_failure to the standard failure track as a default. This can be changed from the user side.
-        options = options.merge(Activity::DSL.Output(:extract_failure) => Activity::DSL.Track(:failure)) unless skip_extract
+        options = options.merge(Activity::DSL.Output(:extract_failure) => Activity::DSL.Track(:failure)) unless skip_extract || representer
 
         options
       end


### PR DESCRIPTION
@apotonick I've made a pull request with the correction you suggested.