### PR TITLE
Do not try to merge extract_failure signal when representer is used

### DIFF
--- a/lib/trailblazer/operation/validate.rb
+++ b/lib/trailblazer/operation/validate.rb
@@ -22,7 +22,7 @@ module Trailblazer
         options = {task: activity, id: "contract.#{name}.validate", outputs: activity.outputs}
 
         # Deviate End.extract_failure to the standard failure track as a default. This can be changed from the user side.
-        options = options.merge(Activity::DSL.Output(:extract_failure) => Activity::DSL.Track(:failure)) unless skip_extract
+        options = options.merge(Activity::DSL.Output(:extract_failure) => Activity::DSL.Track(:failure)) unless skip_extract || representer
 
         options
       end


### PR DESCRIPTION
This should close https://github.com/trailblazer/trailblazer-macro-contract/issues/9

We don't have many tests (any tests with representer) - should we merge this for now and add an issue to add those tests?