### PR TITLE
Update the build contract to include the name

### DIFF
--- a/lib/trailblazer/operation/contract.rb
+++ b/lib/trailblazer/operation/contract.rb
@@ -9,7 +9,7 @@ module Trailblazer
               [options, flow_options]
         end
 
-        {task: task, id: "contract.build"}
+        {task: task, id: "contract.#{name}.build"}
       end
 
       module Build

--- a/test/docs/contract_test.rb
+++ b/test/docs/contract_test.rb
@@ -59,7 +59,7 @@ class DocsContractOverviewTest < Minitest::Spec
     result.wtf.gsub(/0x\w+/, "").must_equal %{`-- DocsContractOverviewTest::Create
    |-- Start.default
    |-- model.build
-   |-- contract.build
+   |-- contract.default.build
    |-- contract.default.validate
    |   |-- Start.default
    |   |-- contract.default.params_extract
@@ -484,7 +484,7 @@ class DocContractTest < Minitest::Spec
       property :id
     end
 
-    step Contract::Build(constant: MyContract), replace: "contract.build"
+    step Contract::Build(constant: MyContract), replace: "contract.default.build"
   end
 
   it { Breach.(params: { id:1, title: "Fame" }).inspect(:model).must_equal %{<Result:true [#<struct DocContractTest::Song id=1, title="Fame">] >} }
@@ -496,7 +496,7 @@ class DocContractTest < Minitest::Spec
       property :id
     end
     # override the original block as if it's never been there.
-    step Contract::Build(constant: MyContract), replace: "contract.build"
+    step Contract::Build(constant: MyContract), replace: "contract.default.build"
   end
 
   it { Break.(params: { id:1, title: "Fame" }).inspect(:model).must_equal %{<Result:true [#<struct DocContractTest::Song id=1, title=nil>] >} }

--- a/test/operation/contract_test.rb
+++ b/test/operation/contract_test.rb
@@ -70,14 +70,14 @@ class ContractTest < Minitest::Spec
     class New < Upsert
     end
 
-    it { Trailblazer::Developer.railway(New).must_equal %{[>model.build,>contract.build,>contract.default.validate,>persist.save]} }
+    it { Trailblazer::Developer.railway(New).must_equal %{[>model.build,>contract.default.build,>contract.default.validate,>persist.save]} }
 
     #- overwriting Validate
     class NewHit < Upsert
       step Contract::Validate( key: :hit ), override: true
     end
 
-    it { Trailblazer::Developer.railway(NewHit).must_equal %{[>model.build,>contract.build,>contract.default.validate,>persist.save]} }
+    it { Trailblazer::Developer.railway(NewHit).must_equal %{[>model.build,>contract.default.build,>contract.default.validate,>persist.save]} }
     it { NewHit.(params: {:hit => { title: "Hooray For Me" }}).inspect(:model).must_equal %{<Result:true [#<struct ContractTest::Song title=\"Hooray For Me\">] >} }
   end
 end

--- a/test/operation/persist_test.rb
+++ b/test/operation/persist_test.rb
@@ -42,7 +42,7 @@ class PersistTest < Minitest::Spec
   class Update < Create
   end
 
-  it { Trailblazer::Developer.railway(Update).must_equal %{[>model.build,>contract.build,>contract.default.validate,<<PersistTest::Create::Fail1,>persist.save,<<PersistTest::Create::Fail2]} }
+  it { Trailblazer::Developer.railway(Update).must_equal %{[>model.build,>contract.default.build,>contract.default.validate,<<PersistTest::Create::Fail1,>persist.save,<<PersistTest::Create::Fail2]} }
 
   #---
   it do


### PR DESCRIPTION
Includes the name passed into the build step in the task hash so if two different Build steps are called, it doesn't throw an error.