### PR TITLE
Symbolize Key for context

### DIFF
--- a/lib/trailblazer/operation/validate.rb
+++ b/lib/trailblazer/operation/validate.rb
@@ -46,7 +46,7 @@ module Trailblazer
         def call(ctx, **)
           validate!(
             ctx,
-            representer: ctx["representer.#{@name}.class"] ||= @representer, # FIXME: maybe @representer should use DI.
+            representer: ctx[:"representer.#{@name}.class"] ||= @representer, # FIXME: maybe @representer should use DI.
             params_path: @params_path
           )
         end


### PR DESCRIPTION
## Description
While working with Trailblazer Developer gem to debug the operation, the following error occurs for contract macro. I have tracked it and found it was due to `ctx["representer.#{@name}.class"]` not being the symbolized key.

```ruby
Failure/Error: result = Dev.wtf?(described_class, params: base_params)     
     TypeError:
       hash key "representer.default.class" is not a Symbol
```
 ### Bug Reproduction
Here is the bug reproduction repository: https://github.com/the-spectator/trb-active-storage-issue/blob/master/spec/concepts/child/operation/update_wtf_spec.rb 