### PR TITLE
allow for contract Build macro to work without params

### DIFF
--- a/lib/trailblazer/macro/contract/validate.rb
+++ b/lib/trailblazer/macro/contract/validate.rb
@@ -33,7 +33,7 @@ module Trailblazer
             @key, @params_path = key, params_path
           end
 
-          def call(ctx, params:, **)
+          def call(ctx, params: {}, **)
             ctx[@params_path] = @key ? params[@key] : params
           end
         end

--- a/test/operation/contract_test.rb
+++ b/test/operation/contract_test.rb
@@ -59,6 +59,8 @@ class ContractTest < Minitest::Spec
     it { Upsert.(params: {song: { title: nil }}).success?.must_equal false }
     # key not found
     it { Upsert.(params: {}).success?.must_equal false }
+    # no params passed
+    it { Upsert.().success?.must_equal false } 
 
     #---
     # contract.default.params gets set (TODO: change in 2.1)


### PR DESCRIPTION
present in an operation