### PR TITLE
feat: Add dynamic ID generation for contract persistence

### DIFF
--- a/lib/trailblazer/macro/contract/persist.rb
+++ b/lib/trailblazer/macro/contract/persist.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Trailblazer
   module Macro
     module Contract
@@ -6,10 +8,14 @@ module Trailblazer
         step = ->(ctx, **) { ctx[path].send(method) }
 
         task = Activity::Circuit::TaskAdapter.for_step(step)
-
+        id = if name == 'default'
+               "persist.#{method}"
+             else
+               "#{path}.persist.#{method}"
+             end
         {
           task: task,
-          id:   "persist.save"
+          id: id
         }
       end
     end

--- a/lib/trailblazer/macro/contract/persist.rb
+++ b/lib/trailblazer/macro/contract/persist.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Trailblazer
   module Macro
     module Contract
@@ -8,14 +6,9 @@ module Trailblazer
         step = ->(ctx, **) { ctx[path].send(method) }
 
         task = Activity::Circuit::TaskAdapter.for_step(step)
-        id = if name == 'default'
-               "persist.#{method}"
-             else
-               "#{path}.persist.#{method}"
-             end
         {
           task: task,
-          id: id
+          id: "persist.#{method}"
         }
       end
     end

--- a/test/operation/contract_test.rb
+++ b/test/operation/contract_test.rb
@@ -72,14 +72,14 @@ class ContractTest < Minitest::Spec
     class New < Upsert
     end
 
-    it { Trailblazer::Developer.railway(New).must_equal %{[>model.build,>contract.build,>contract.default.validate,>persist.save]} }
+    it { Trailblazer::Developer.railway(New).must_equal %{[>model.build,>contract.build,>contract.default.validate,>persist.sync]} }
 
     #- overwriting Validate
     class NewHit < Upsert
       step Contract::Validate(key: :hit), override: true
     end
 
-    it { Trailblazer::Developer.railway(NewHit).must_equal %{[>model.build,>contract.build,>contract.default.validate,>persist.save]} }
+    it { Trailblazer::Developer.railway(NewHit).must_equal %{[>model.build,>contract.build,>contract.default.validate,>persist.sync]} }
     it { NewHit.(params: {:hit => { title: "Hooray For Me" }}).inspect(:model).must_equal %{<Result:true [#<struct ContractTest::Song title=\"Hooray For Me\">] >} }
   end
 end

--- a/test/operation/contract_test.rb
+++ b/test/operation/contract_test.rb
@@ -22,6 +22,11 @@ class ContractTest < Minitest::Spec
       ->(*) { validate(options["params"][:song]) } # <-- TODO
     end
 
+    class UpdateHit < Update
+      step Contract::Persist( method: :sync ), id: 'persist.syncer'
+      step Contract::Persist()
+    end
+
     # success
     it do
       result = Update.(params: {title: "SVG"})
@@ -36,6 +41,12 @@ class ContractTest < Minitest::Spec
       result.success?.must_equal false
       result[:"result.contract.default"].success?.must_equal false
       result[:"result.contract.default"].errors.messages.must_equal({:title=>["can't be blank"]})
+    end
+
+    # override id
+    it 'override id' do
+      railway = Trailblazer::Developer.railway(UpdateHit)
+      assert_equal railway, %([>model.build,>contract.build,>contract.default.validate,>persist.syncer,>persist.save])
     end
 
     #---

--- a/test/operation/persist_test.rb
+++ b/test/operation/persist_test.rb
@@ -21,9 +21,9 @@ class PersistTest < Minitest::Spec
     step Model( Song, :new )
     step Contract::Build( constant: Form )
     step Contract::Validate()
-    fail Fail1
+    left Fail1
     step Contract::Persist()
-    fail Fail2
+    left Fail2
   end
 
   it { Create.(params: { title: "In Recital" })[:model].title.must_equal "In Recital" }

--- a/trailblazer-macro-contract.gemspec
+++ b/trailblazer-macro-contract.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.email         = ["apotonick@gmail.com"]
   spec.description   = 'Operation macros for form objects'
   spec.summary       = 'Macros for form objects: Build, Validate, Persist'
-  spec.homepage      = "http://trailblazer.to"
+  spec.homepage      = "https://trailblazer.to"
   spec.license       = "LGPL-3.0"
 
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|


### PR DESCRIPTION
Introduce logic to generate dynamic task IDs based on the contract name and method for better clarity and specificity. 

This allow using sync and save in the same operation without affecting setting IDs manually.